### PR TITLE
Add animated menus with sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ Welcome to Breakout Blast, a vibrant and exciting breakout game with a twist! Ge
 ```
 ## How to Play
 
+Press **Enter** on the animated title screen to start a new game.
+The menu features background music and simple animations.
+
 Spacebar to pause the game!
+
+When you win or lose, press **R** to restart.
 
 1. Use the left and right arrow keys or the A and D keys to move the paddle horizontally (or use your mouse).
 


### PR DESCRIPTION
## Summary
- polish the menu flow with looping menu music
- add GIF animation to the title screen and pulsing text
- play a sound when starting or restarting the game
- animate win and game over screens
- document new animated menu in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684115daaa7083259289728d8b7f5177