### PR TITLE
Fix soundFormats crash

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -59,11 +59,23 @@ let menuMusic;
 let menuGif;
 
 function preload() {
-    // Ensure soundFormats exists in environments where the p5.sound
-    // library might not be available. This prevents a runtime error
-    // that stops asset loading when sound support is missing.
+    // Ensure p5.sound APIs exist in environments where the sound
+    // library might not be available. This prevents runtime errors
+    // that stop asset loading when sound support is missing.
     if (typeof soundFormats === 'function') {
         soundFormats('mp3', 'ogg');
+    }
+
+    if (typeof loadSound !== 'function') {
+        // Provide a stub loadSound that returns an object with the
+        // sound methods used in this game.
+        window.loadSound = () => ({
+            play() { },
+            stop() { },
+            setLoop() { },
+            setVolume() { },
+            isPlaying() { return false; }
+        });
     }
     //images
     backgroundImage = loadImage('Assets/background1.png')

--- a/sketch.js
+++ b/sketch.js
@@ -59,7 +59,12 @@ let menuMusic;
 let menuGif;
 
 function preload() {
-    soundFormats('mp3', 'ogg');
+    // Ensure soundFormats exists in environments where the p5.sound
+    // library might not be available. This prevents a runtime error
+    // that stops asset loading when sound support is missing.
+    if (typeof soundFormats === 'function') {
+        soundFormats('mp3', 'ogg');
+    }
     //images
     backgroundImage = loadImage('Assets/background1.png')
     paddleImage = loadImage('Assets/paddle.png')


### PR DESCRIPTION
## Summary
- guard `soundFormats()` call in `preload` to prevent crash if the p5.sound library isn't loaded

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68411a24b2e88325939f927caa3736d5