### PR TITLE
Fix menu initialization errors and refresh UI styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,8 @@
          removal of registerMethod) that stop the sketch from running. -->
     <script src="https://cdn.jsdelivr.net/npm/p5@1.6.0/lib/p5.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/p5@1.6.0/lib/addons/p5.sound.min.js"></script>
-    
-    <script src="https://cdn.jsdelivr.net/npm/planck@latest/dist/planck.min.js"></script>
-    <script src="https://p5play.org/v3/p5.play.js"></script>
+
+    <link rel="icon" type="image/png" href="Assets/ball.png">
     <link rel="stylesheet" type="text/css" href="style.css">
     <meta charset="utf-8" />
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,14 @@
 html, body {
     margin: 0;
     padding: 0;
-  }
-  canvas {
+    height: 100%;
+    background-color: #000;
+}
+
+main {
+    min-height: 100vh;
+}
+
+canvas {
     display: block;
-  }
+}


### PR DESCRIPTION
## Summary
- remove unused Planck/p5play scripts and add a favicon reference to stop console errors
- update the laser power-up logic to run without p5play and keep its visual effect
- tweak global styles so the canvas sits on a black backdrop instead of a white gutter

## Testing
- Manual: Loaded http://localhost:8000/index.html via `python3 -m http.server 8000` and confirmed the menu renders without errors

------
https://chatgpt.com/codex/tasks/task_e_68eacbfaf3f08325bbc4469c0fd2fe06